### PR TITLE
Implement a basic B+Tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "petgraph",
  "rand",
  "rustyline",
+ "sqlparser",
  "tempfile",
  "zerocopy",
 ]
@@ -709,6 +710,15 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "sqlparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca597d77c98894be1f965f2e4e2d2a61575d4998088e655476c73715c54b2b43"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -554,18 +554,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -744,6 +744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +797,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.100",
 ]
 
 [[package]]
@@ -996,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.1"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1006,11 +1017,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.3.2"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.42",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ atomic = "0.5.3"
 bitvec = "1.0.1"
 aes = "0.8.2"
 hex = "0.4.3"
+sqlparser = "0.35.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2.139"
 parking_lot = { version = "0.12.1", features = ["arc_lock"] }
 nom = "^7"
 rustyline = "11.0.0"
-zerocopy = "0.6.1"
+zerocopy = { version = "0.7.32", features = ["alloc", "derive", "simd"] }
 ahash = "0.8.3"
 atomic = "0.5.3"
 bitvec = "1.0.1"

--- a/src/access/btree_segment.rs
+++ b/src/access/btree_segment.rs
@@ -1,7 +1,7 @@
 
-// TODO: Implement a B+Tree using (optimistic) latch crabbing
-// We will implement right-links on the leaf pages for now but not left-links bc. of deadlocks
+// Implementation of a B+Tree with right-links on the leaf pages for now but not left-links bc. of deadlocks
 // Could also implement a B-Link tree using latching approach described in Lehmans & Yao paper
+// like Postgres does but this should be good enough for a MVP
 
 use std::{mem::size_of, cmp::Ordering, ops::Deref};
 
@@ -231,6 +231,7 @@ impl<B: BufferManager> OrderedIndex<B> for BTreeSegment<B> {
     type ScanIterator = BTreeScan<B>;
 
     fn scan(&self, _from: Option<&[Option<TupleValue>]>, _to: Option<&[Option<TupleValue>]>) -> Result<Self::ScanIterator, <B as BufferManager>::BError> {
+        // TODO: Implement this (cache matching TIDs (at least up to a few thousand entryies) upon construction to hold locks for as short as possible?)
         todo!()
     }
 }
@@ -250,6 +251,8 @@ impl Slot {
         }
     }
 }
+
+// TODO: Split BTreePage up into BTreeInnerPage and BTreeLeafPage again?
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, Unaligned)]
@@ -776,5 +779,7 @@ mod test {
         }
         assert!(scan.next().is_none());
     }
+
+    // TODO: Multithreaded tests
 
 }

--- a/src/access/btree_segment.rs
+++ b/src/access/btree_segment.rs
@@ -21,6 +21,7 @@ pub struct BTreeSegment<B: BufferManager> {
     key_attributes: Vec<TupleValueType>
 }
 
+#[allow(dead_code)]
 impl<B: BufferManager> BTreeSegment<B> {
     pub fn new(bm: B, segment_id: SegmentId, key_attributes: Vec<TupleValueType>) -> Self {
         Self {

--- a/src/access/btree_segment.rs
+++ b/src/access/btree_segment.rs
@@ -6,12 +6,15 @@
 use std::{mem::size_of, cmp::Ordering, ops::Deref};
 
 use byteorder::{BigEndian, NativeEndian};
-use zerocopy::{AsBytes, FromBytes, LayoutVerified, ByteSlice, ByteSliceMut, Unaligned, U16, U32, U64};
+use zerocopy::{AsBytes, FromBytes, ByteSlice, ByteSliceMut, Unaligned, U16, U32, U64, FromZeroes, Ref};
 
-use crate::{storage::{buffer_manager::{BufferManager, BMArcReadGuard, BMArc}, page::{SegmentId, PageId, Page}}, types::{TupleValue, RelationTID, TupleValueType}};
+use crate::{storage::{buffer_manager::{BufferManager, BMArc, BMArcUpgradeableReadGuard, BMArcReadGuard}, page::{SegmentId, PageId, Page}}, types::{TupleValue, RelationTID, TupleValueType}};
 
 use super::{index::{OrderedIndex, Index}, tuple::Tuple};
 
+// A B+Tree. It will always be unique. If we want an index with duplicates, we append the TID to the key.
+
+#[derive(Clone, Debug)]
 pub struct BTreeSegment<B: BufferManager> {
     bm: B,
     segment_id: SegmentId,
@@ -27,10 +30,40 @@ impl<B: BufferManager> BTreeSegment<B> {
         }
     }
 
+    pub fn init(&self) {
+        let metadata_page = self.bm.fix_page(PageId::new(self.segment_id, 0)).unwrap();
+        let mut metadata_write = metadata_page.write();
+        metadata_write[0..8].copy_from_slice(&1u64.to_be_bytes());
+        let root_page = self.bm.fix_page(PageId::new(self.segment_id, 1)).unwrap();
+        let mut root_write = root_page.write();
+        let mut root_leaf = BTreePage::parse(root_write.as_mut()).unwrap();
+        root_leaf.init(true);
+        root_leaf.header.flags.set(1); // Leaf
+    }
+
+    pub fn lower_bound(self, key: &[Option<TupleValue>]) -> Result<BTreeScan<B>, B::BError> {
+        let (_, leaf_page_guard) = self.lookup_leaf_page(key, |b| b.read_owning())?;
+        let leaf_page = BTreePage::parse(leaf_page_guard.as_ref()).unwrap();
+
+        if let Some((slot_id, _)) = leaf_page.binary_search_slot(|v| {
+                let tuple = Tuple::parse_binary_all(&self.key_attributes, v);
+                key.partial_cmp(tuple.values.as_slice()).unwrap()
+            }) {
+            Ok(BTreeScan {
+                segment: self,
+                slot_id: slot_id as u16,
+                page_guard: Some(leaf_page_guard)
+            })
+        } else {
+            return Ok(BTreeScan { segment: self, page_guard: None, slot_id: 0 });
+        }
+    }
+
     fn lookup_leaf_page<T: Deref<Target=Page>>(&self, key: &[Option<TupleValue>], lock: fn(BMArc<B>) -> T)-> Result<(T,T), B::BError> {
         let mut parent_page = lock(self.bm.fix_page(PageId::new(self.segment_id, 0))?);
-        let root_page: u64 = u64::from_be_bytes(parent_page[0..8].try_into().unwrap());
-        let root_page = self.bm.fix_page(PageId::new(self.segment_id, root_page))?;
+        let root_page_offset: u64 = u64::from_be_bytes(parent_page[0..8].try_into().unwrap());
+        let root_page = self.bm.fix_page(PageId::new(self.segment_id, root_page_offset))?;
+        let mut current_page_offset = root_page_offset;
         let mut current_page = lock(root_page);
         loop {
             if current_page[1] & 1 == 1 {
@@ -39,14 +72,18 @@ impl<B: BufferManager> BTreeSegment<B> {
             }
             drop(parent_page);
             // Still inner nodes
-            let current_bt_page = BTreeInnerPage::parse(current_page.as_ref()).unwrap();
-            let next_page_id = current_bt_page.binary_search(|val| {
-                let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
-                key.partial_cmp(tuple.values.as_slice()).unwrap()
-            });
-            let next_page = self.bm.fix_page(PageId::new(self.segment_id, next_page_id))?;
+            let current_bt_page = BTreePage::parse(current_page.as_ref()).unwrap();
+            let next_page_offset =  current_bt_page.search_inner(|val| {
+                        let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                        key.partial_cmp(tuple.values.as_slice()).unwrap()
+                    });
+            assert_ne!(next_page_offset, u64::MAX, "BTree corrupted");
+            assert_ne!(next_page_offset, 0, "BTree corrupted");
+            assert_ne!(next_page_offset, current_page_offset, "BTree corrupted");
+            let next_page = self.bm.fix_page(PageId::new(self.segment_id, next_page_offset))?;
             parent_page = current_page;
             current_page = lock(next_page);
+            current_page_offset = next_page_offset;
         }
     }
 }
@@ -54,65 +91,136 @@ impl<B: BufferManager> BTreeSegment<B> {
 impl<B: BufferManager> Index<B> for BTreeSegment<B> {
     fn lookup(&self, key: &[Option<TupleValue>]) -> Result<Option<RelationTID>, B::BError> {
         let (_, leaf_page_raw) = self.lookup_leaf_page(key, |b| b.read_owning())?;
-        let leaf_page = BTreeLeafPage::parse(leaf_page_raw.as_ref()).unwrap();
+        let leaf_page = BTreePage::parse(leaf_page_raw.as_ref()).unwrap();
         Ok(leaf_page.binary_search(|val| {
             let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
             key.partial_cmp(tuple.values.as_slice()).unwrap()
-        }))
+        }).map(|tid| RelationTID::from(tid)))
     }
 
-    fn insert(&self, key: &[Option<TupleValue>], tid: RelationTID) -> Result<(), B::BError> {
+    fn insert(&self, key: &[Option<TupleValue>], tid: RelationTID) -> Result<bool, B::BError> {
         // We first try the happy path: Taking read latches all the way down and only write locking the leaf page
         // if we need to split the leaf page, we will retry and take a stack of write latches all the way down
         // Since we have variable length keys (potentially, but we won't optimize the fixed-size case for now)
         // we cannot do eager splitting and will instead have to split on demand
         let (parent_page, page) = self.lookup_leaf_page(key, |r| r.upgradeable_read_owning())?;
-        let leaf_page = BTreeLeafPage::parse(page.as_ref()).unwrap();
+        let leaf_page = BTreePage::parse(page.as_ref()).unwrap();
         let key_binary = Tuple::new(key).get_binary();
+        let insert_cmp = |val: &[u8]| {
+            let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+            key.partial_cmp(tuple.values.as_slice()).unwrap()
+        };
         if key_binary.len() + 8 + 8 <= leaf_page.header.free_space.get() as usize {
             // don't need to split -> just insert
             let mut upgraded_page = page.upgrade();
-            let mut leaf_page = BTreeLeafPage::parse(upgraded_page.as_mut()).unwrap();
-            leaf_page.insert(|val| {
-                let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
-                key.partial_cmp(tuple.values.as_slice()).unwrap()
-            }, &key_binary, tid).unwrap();
-            Ok(())
+            let mut leaf_page = BTreePage::parse(upgraded_page.as_mut()).unwrap();
+            let res = leaf_page.insert(insert_cmp, &key_binary, u64::from(&tid));
+            Ok(res.is_ok())
         } else {
-            // need to split -> does the parent have enough space? if yes upgrade parent latch and split
+            // TODO: need to split -> does the parent have enough space? if yes upgrade parent latch and split
             // else take write-latches all the way down and keep them
             drop(leaf_page);
             drop(page);
-            let mut latch_stack = Vec::new();
-            let mut parent_page = self.bm.fix_page(PageId::new(self.segment_id, 0))?.write_owning();
-            let root_page: u64 = u64::from_be_bytes(parent_page[0..8].try_into().unwrap());
-            let root_page = self.bm.fix_page(PageId::new(self.segment_id, root_page))?;
-            let mut current_page = root_page.write_owning();
+            drop(parent_page);
+            let mut latch_stack: Vec<BMArcUpgradeableReadGuard<B>> = Vec::new();
+            let mut parent_page = self.bm.fix_page(PageId::new(self.segment_id, 0))?.upgradeable_read_owning();
+            let root_page_id: u64 = u64::from_be_bytes(parent_page[0..8].try_into().unwrap());
+            let root_page = self.bm.fix_page(PageId::new(self.segment_id, root_page_id))?;
+            let mut current_page = root_page.upgradeable_read_owning();
             loop {
                 if current_page[1] & 1 == 1 {
                     // Leaf page
-                    let mut leaf_page = BTreeLeafPage::parse(current_page.as_mut()).unwrap();
-                    if key_binary.len() + 8 + 8 <= leaf_page.header.free_space.get() as usize {
+                    let mut upgraded_page = current_page.upgrade();
+                    let mut leaf_page = BTreePage::parse(upgraded_page.as_mut()).unwrap();
+                    let free_space = leaf_page.header.free_space.get() as usize;
+                    if key_binary.len() + 8 + 8 <= free_space {
                         // don't need to split -> just insert
-                        leaf_page.insert(|val| {
-                            let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
-                            key.partial_cmp(tuple.values.as_slice()).unwrap()
-                        }, &key_binary, tid).unwrap();
-                        return Ok(());
+                        leaf_page.insert(insert_cmp, &key_binary, u64::from(&tid)).unwrap();
+                        return Ok(true);
                     } else {
-
+                        latch_stack.push(parent_page);
+                        // split
+                        let mut new_pid = self.bm.allocate_page(self.segment_id);
+                        let mut split_page_write = self.bm.fix_page(new_pid)?.write_owning();
+                        let mut split_bt_page = BTreePage::parse(split_page_write.as_mut()).unwrap();
+                        let mut split_key = leaf_page.leaf_split_into(&mut split_bt_page, new_pid.offset_id);
+                        let mut split_key_tuple = Tuple::parse_binary_all(&self.key_attributes, &split_key);
+                        // insert the actual tuple
+                        if key.partial_cmp(split_key_tuple.values.as_slice()).unwrap() != Ordering::Greater {
+                            // Insert into original page
+                            let res = leaf_page.insert(insert_cmp, &key_binary, u64::from(&tid));
+                            if res.is_err() {
+                                return Ok(false);
+                            }
+                        } else {
+                            // Insert into new page
+                            let res = split_bt_page.insert(insert_cmp, &key_binary, u64::from(&tid));
+                            if res.is_err() {
+                                return Ok(false);
+                            }
+                        }
+                        while latch_stack.len() > 1{
+                            let mut parent_page = latch_stack.pop().unwrap().upgrade();
+                            let mut parent_bt_page = BTreePage::parse(parent_page.as_mut()).unwrap();
+                            if parent_bt_page.header.free_space.get() as usize >= split_key.len() + 8 + 8 {
+                                // don't need to split -> just insert
+                                let res = parent_bt_page.insert(|val| {
+                                    let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                                    split_key_tuple.values.as_slice().partial_cmp(tuple.values.as_slice()).unwrap()
+                                }, &split_key, new_pid.offset_id);
+                                return Ok(res.is_ok());
+                            } else {
+                                // split
+                                new_pid = self.bm.allocate_page(self.segment_id);
+                                split_page_write = self.bm.fix_page(new_pid)?.write_owning();
+                                let mut split_bt_page = BTreePage::parse(split_page_write.as_mut()).unwrap();
+                                let split_key_new = parent_bt_page.inner_split_into(&mut split_bt_page);
+                                let split_key_tuple_new = Tuple::parse_binary_all(&self.key_attributes, &split_key);
+                                let insert_page = if key.partial_cmp(split_key_tuple.values.as_slice()).unwrap() == Ordering::Less {
+                                    // Insert into original page
+                                    &mut parent_bt_page
+                                } else {
+                                    // Insert into new page
+                                    &mut split_bt_page
+                                };
+                                let res = insert_page.insert(|val| {
+                                    let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                                    split_key_tuple.values.as_slice().partial_cmp(tuple.values.as_slice()).unwrap()
+                                }, &split_key, new_pid.offset_id); // TODO: This could still fail with large keys
+                                if res.is_err() {
+                                    return Ok(false);
+                                }
+                                split_key = split_key_new;
+                                split_key_tuple = split_key_tuple_new;
+                            }
+                        }
+                        let meta_page_lock = latch_stack.pop().unwrap();
+                        let mut meta_page = meta_page_lock.upgrade();
+                        let new_root_pid = self.bm.allocate_page(self.segment_id);
+                        let new_root_page = self.bm.fix_page(new_root_pid)?;
+                        let mut new_root_page_write = new_root_page.write();
+                        let mut new_root_bt_page = BTreePage::parse(new_root_page_write.as_mut()).unwrap();
+                        new_root_bt_page.init(false);
+                        new_root_bt_page.header.first_next_pointer.set(root_page_id);
+                        new_root_bt_page.insert(|val| {
+                            let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                            split_key_tuple.values.as_slice().partial_cmp(tuple.values.as_slice()).unwrap()
+                        }, &split_key, new_pid.offset_id).unwrap();
+                        meta_page[0..8].copy_from_slice(&new_root_pid.offset_id.to_be_bytes());
+                        return Ok(true);
                     }
+                } else {
+                    latch_stack.push(parent_page);
+                    // Still inner nodes
+                    let current_bt_page = BTreePage::parse(current_page.as_ref()).unwrap();
+                    let next_page_id = current_bt_page.search_inner(|val| {
+                                let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                                key.partial_cmp(tuple.values.as_slice()).unwrap()
+                            });
+                    let next_page = self.bm.fix_page(PageId::new(self.segment_id, next_page_id))?;
+                    parent_page = current_page;
+                    current_page = next_page.upgradeable_read_owning();
                 }
-                latch_stack.push(parent_page);
-                // Still inner nodes
-                let current_bt_page = BTreeInnerPage::parse(current_page.as_ref()).unwrap();
-                let next_page_id = current_bt_page.binary_search(|val| {
-                    let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
-                    key.partial_cmp(tuple.values.as_slice()).unwrap()
-                });
-                let next_page = self.bm.fix_page(PageId::new(self.segment_id, next_page_id))?;
-                parent_page = current_page;
-                current_page = next_page.write_owning();
             }
         }
     }
@@ -122,119 +230,66 @@ impl<B: BufferManager> OrderedIndex<B> for BTreeSegment<B> {
 
     type ScanIterator = BTreeScan<B>;
 
-    fn scan(&self, from: &[Option<TupleValue>], to: &[Option<TupleValue>]) -> Result<Self::ScanIterator, <B as BufferManager>::BError> {
+    fn scan(&self, _from: Option<&[Option<TupleValue>]>, _to: Option<&[Option<TupleValue>]>) -> Result<Self::ScanIterator, <B as BufferManager>::BError> {
         todo!()
     }
 }
 
-// 16 bit slot count, 16 bit first free slot, 32 bit data start, 32 bit free space
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
-struct BTreePageInnerHeader {
-    flags: U16<BigEndian>,
-    slot_count: U16<NativeEndian>,
-    data_start: U32<NativeEndian>,
-    free_space: U32<NativeEndian>,
-    last_pointer: U64<NativeEndian>
-}
-
-/*
-    The inner page contains the header after which the slots follow. 
-    The values contain a variable sized tuple (the key) followed by a 64 bit page id.
- */
-
-#[repr(C)]
-#[derive(FromBytes)]
-struct BTreeInnerPage<B: ByteSlice> {
-    header: LayoutVerified<B, BTreePageInnerHeader>,
-    data: B
-}
-
-#[repr(C)]
-#[derive(FromBytes, Unaligned, AsBytes)]
+#[derive(FromBytes, FromZeroes, Unaligned, AsBytes)]
 struct Slot {
     offset: U32<NativeEndian>,
     length: U32<NativeEndian>
 }
 
-impl<B: ByteSlice> BTreeInnerPage<B> {
-    fn parse(bytes: B) -> Option<BTreeInnerPage<B>> {
-        let (header, data) = LayoutVerified::new_unaligned_from_prefix(bytes)?;
-        Some(BTreeInnerPage { header, data })
-    }
-
-    fn get_slots(&self) -> &[Slot] {
-        let slot_count = self.header.slot_count.get() as usize;
-        let slot_size = size_of::<Slot>();
-        let slots = &self.data.as_ref()[0..slot_count * slot_size];
-        let layout: LayoutVerified<&[u8], [Slot]> = LayoutVerified::new_slice(slots).unwrap();
-        layout.into_slice()
-    }
-
-    fn binary_search<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> u64 {
-        let slots = self.get_slots();
-        let mut left = 0;
-        let mut right = slots.len();
-        while left < right {
-            let mid = (left + right) / 2;
-            let slot = &slots[mid];
-            let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
-            match comp(&data[..data.len() - 8]) {
-                Ordering::Less => {
-                    right = mid;
-                },
-                Ordering::Equal => {
-                    return u64::from_be_bytes(data[data.len() - 8..].try_into().unwrap());
-                },
-                Ordering::Greater => {
-                    left = mid + 1;
-                }
-            }
-        }
-        if right == slots.len() {
-            self.header.last_pointer.get()
-        } else {
-            let slot = &slots[right];
-            let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
-            u64::from_be_bytes(data[data.len() - 8..].try_into().unwrap())
+impl Slot {
+    fn new(offset: u32, length: u32) -> Self {
+        Self {
+            offset: U32::<NativeEndian>::new(offset),
+            length: U32::<NativeEndian>::new(length)
         }
     }
-    
 }
 
-impl<B: ByteSliceMut> BTreeInnerPage<B> {
-    
-}
-
-// 16 bit slot count, 16 bit first free slot, 32 bit data start, 32 bit free space
 #[repr(C)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
-struct BTreePageLeafHeader {
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes, Unaligned)]
+struct BTreePageHeader {
     flags: U16<BigEndian>,
     slot_count: U16<NativeEndian>,
     data_start: U32<NativeEndian>, // Not really necessary. It's just the offset of the first slot
     free_space: U32<NativeEndian>, // Not really necessary. It's just the data length minus data_start
+    first_next_pointer: U64<NativeEndian> // First (less than first key) Pointer for inner pages, next pointer for leaf pages
 }
 
 #[repr(C)]
-#[derive(FromBytes)]
-struct BTreeLeafPage<B: ByteSlice> {
-    header: LayoutVerified<B, BTreePageLeafHeader>,
+#[derive(FromBytes, FromZeroes)]
+struct BTreePage<B: ByteSlice> {
+    header: Ref<B, BTreePageHeader>,
     data: B
 }
 
-impl<B: ByteSlice> BTreeLeafPage<B> {
-    pub fn parse(bytes: B) -> Option<BTreeLeafPage<B>> {
-        let (header, data) = LayoutVerified::new_unaligned_from_prefix(bytes)?;
-        Some(BTreeLeafPage { header, data })
+impl<B: ByteSlice> BTreePage<B> {
+    #[allow(dead_code)]
+    fn is_inner(&self) -> bool {
+        self.header.flags.get() & 1 == 0
+    }
+
+    pub fn parse(bytes: B) -> Option<BTreePage<B>> {
+        let (header, data) = Ref::new_unaligned_from_prefix(bytes)?;
+        Some(BTreePage { header, data })
     }
 
     fn get_slots(&self) -> &[Slot] {
         let slot_count = self.header.slot_count.get() as usize;
         let slot_size = size_of::<Slot>();
         let slots = &self.data.as_ref()[0..slot_count * slot_size];
-        let layout: LayoutVerified<&[u8], [Slot]> = LayoutVerified::new_slice(slots).unwrap();
+        let layout: Ref<&[u8], [Slot]> = Ref::new_slice(slots).unwrap();
         layout.into_slice()
+    }
+
+    fn get_item(&self, slot_id: u16) -> &[u8] {
+        let slot = &self.get_slots()[slot_id as usize];
+        &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize]
     }
 
     fn binary_search_slot<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> Option<(usize, bool)> {
@@ -262,12 +317,25 @@ impl<B: ByteSlice> BTreeLeafPage<B> {
             let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
             if comp(&data[..data.len() - 8]) == Ordering::Equal {
                 return Some((right, true));
+            } else {
+                return Some((right, false));
             }
         }
         None
     }
 
-    fn binary_search<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> Option<RelationTID> {
+    fn lower_bound<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> Option<u64> {
+        self.binary_search_slot(comp).map(|(s, _)| {
+            let slot = &self.get_slots()[s];
+            let value_end = (slot.offset.get() + slot.length.get()) as usize;
+            let value_start = value_end - 8;
+            // Don't check whether the key actually matches
+            Some(u64::from_be_bytes(self.data[value_start..value_end].try_into().unwrap()))
+        }
+        ).flatten()
+    }
+
+    fn binary_search<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> Option<u64> {
         self.binary_search_slot(comp).map(|(s, exact_match)| {
             let slot = &self.get_slots()[s];
             let value_end = (slot.offset.get() + slot.length.get()) as usize;
@@ -276,92 +344,437 @@ impl<B: ByteSlice> BTreeLeafPage<B> {
             if !exact_match {
                 return None;
             }
-            Some(RelationTID::from(u64::from_be_bytes(self.data[value_start..value_end].try_into().unwrap())))
+            Some(u64::from_be_bytes(self.data[value_start..value_end].try_into().unwrap()))
         }
         ).flatten()
     }
+
+    fn search_inner<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> u64 {
+        let mut slot_id = self.binary_search_slot(comp)
+                    .map(|(s, _)| s)
+                    .unwrap_or(self.header.slot_count.get() as usize);
+        if slot_id == 0 {
+            return self.header.first_next_pointer.get();
+        }
+        slot_id -= 1;
+        let slot = &self.get_slots()[slot_id];
+        let value_end = (slot.offset.get() + slot.length.get()) as usize;
+        let value_start = value_end - 8;
+        // Don't check whether the key actually matches
+        u64::from_be_bytes(self.data[value_start..value_end].try_into().unwrap())
+    }
 }
 
-impl<B: ByteSliceMut> BTreeLeafPage<B> {
+impl<B: ByteSliceMut> BTreePage<B> {
 
-    fn insert<C: Fn(&[u8]) -> Ordering>(&mut self, comp: C, key: &[u8], value: RelationTID) -> Result<(), ()> {
+    fn init(&mut self, is_leaf: bool) {
+        self.header.free_space.set(self.data.len() as u32);
+        self.header.data_start.set(self.data.len() as u32);
+        self.header.slot_count.set(0);
+        self.header.first_next_pointer.set(u64::MAX);
+        let flags_value = if is_leaf { 1 } else { 0 };
+        self.header.flags.set(flags_value);
+    }
+
+    fn get_slots_mut(&mut self) -> &mut [Slot] {
+        let slot_count = self.header.slot_count.get() as usize;
+        let slot_size = size_of::<Slot>();
+        let slots = &mut self.data.as_mut()[0..slot_count * slot_size];
+        let layout: Ref<&mut [u8], [Slot]> = Ref::new_slice(slots).unwrap();
+        layout.into_mut_slice()
+    }
+
+    fn insert<C: Fn(&[u8]) -> Ordering>(&mut self, comp: C, key: &[u8], value: u64) -> Result<usize, ()> {
+        let insert_len = key.len() + 8;
         let slot = self.binary_search_slot(comp).to_owned();
         let (slot_index, move_end) = if let Some((slot_index, exact_match)) = slot {
             if exact_match {
+                // We don't want actual duplicates on this level since this will destroy worst case O(log n) performance
+                // Insert with a tie breaker key if you want duplicates
                 return Err(());
             }
             let slot: &Slot = &self.get_slots()[slot_index];
             (slot_index, (slot.offset.get() + slot.length.get()) as usize)
         } else {
             // Insert at the end
-            (self.header.slot_count.get() as usize, self.data.len())
+            (self.header.slot_count.get() as usize, self.header.data_start.get() as usize)
         };
-        // Move greaters slots and insert
-        self.data.copy_within(self.header.slot_count.get() as usize * size_of::<Slot>()..move_end, self.header.slot_count.get() as usize * size_of::<Slot>() - size_of::<Slot>());
-        // Move smaller elements and insert
-        let insert_len = key.len() + 8;
+        // Move greater slots and insert
+        self.data.copy_within(slot_index * size_of::<Slot>()..self.header.slot_count.get() as usize * size_of::<Slot>(), slot_index * size_of::<Slot>() + size_of::<Slot>());
+        let new_slot_count = self.header.slot_count.get() + 1;
+        self.header.slot_count.set(new_slot_count);
+        let slots = self.get_slots_mut();
+        slots[slot_index] = Slot::new(move_end as u32 - insert_len as u32, insert_len as u32);
+        for slot in &mut slots[slot_index+1..] {
+            slot.offset.set(slot.offset.get() - insert_len as u32);
+        }
+        // Move larger elements and insert
         self.data.copy_within(self.header.data_start.get() as usize..move_end, self.header.data_start.get() as usize - insert_len);
         self.data[move_end-insert_len..move_end-8].copy_from_slice(key);
-        self.data[move_end-8..move_end].copy_from_slice(&u64::from(&value).to_be_bytes());
+        self.data[move_end-8..move_end].copy_from_slice(&value.to_be_bytes());
         // Update header
-        let slots = self.header.slot_count.get();
-        self.header.slot_count.set(slots + 1);
-        let data_start = self.header.data_start.get();
-        self.header.data_start.set(data_start - insert_len as u32);
-        let free_space = self.header.free_space.get();
-        self.header.free_space.set(free_space - insert_len as u32);
-        Ok(())
+        self.header.data_start -= (insert_len as u32).into();
+        self.header.free_space -= (insert_len as u32 + 8).into();
+        Ok(slot_index)
     }
 
-    fn split_into(&mut self, other: &mut Self) {
+    fn inner_split_into(&mut self, other: &mut Self) -> Box<[u8]> {
         let mut split_index = 0;
         let mut cumulative_size = 0;
         let slots = self.get_slots();
         // We want that both pages have at least (PAGE_SIZE - HEADER_SIZE) / 2 space after the split
-        while ((cumulative_size + slots[split_index].length.get()) as usize)  < self.data.len() / 2 {
+        while ((cumulative_size + slots[split_index].length.get()) as usize + 8 * (split_index + 1))  < self.data.len() / 2 {
             let slot = &slots[split_index];
             cumulative_size += slot.length.get();
             split_index += 1;
         }
-        let split_key = self.data.as_ref()[slots[split_index].offset.get() as usize..(slots[split_index].offset.get() + slots[split_index].length.get() - 8) as usize].to_owned();
+        let split_key_data = self.get_item(split_index as u16);
+        let split_key = split_key_data[..split_key_data.len() - 8].to_owned();
+        let split_key_value = u64::from_be_bytes(split_key_data[split_key_data.len() - 8..].try_into().unwrap());
         let old_data_start = self.header.data_start.get() as usize;
-        let new_other_size = self.data.len() - old_data_start - cumulative_size as usize - split_key.len();
-        let other_data_start = other.data.len() - new_other_size;
-        let other_data_end = other.data.len();
-        let data_to_copy = &self.data[self.data.len() - new_other_size..self.data.len()];
-        other.data[other_data_start..other_data_end].copy_from_slice(data_to_copy);
         let data_end = self.data.len();
         let new_data_start = data_end - cumulative_size as usize;
-        self.data.copy_within(old_data_start..data_end, new_data_start);
-        // Update slotsenumerate
-        let mut data_start = other.data.len() as u32;
-        let slots = self.get_slots();
-        for slot_index in (0..split_index).rev() {
+        let other_size = new_data_start - old_data_start - split_key_data.len();
+        let other_data_start = other.data.len() - other_size;
+        let other_data_end = other.data.len();
+        let data_to_copy = &self.data[old_data_start..new_data_start];
+        other.data[other_data_start..other_data_end].copy_from_slice(data_to_copy);
+        // Update slots
+        let slots = self.get_slots_mut();
+        let mut other_data_start = other.data.len() as u32;
+        for slot_index in split_index + 1..slots.len() {
             let length = U32::<NativeEndian>::from(slots[slot_index].length.get());
-            let offset = U32::<NativeEndian>::from(data_start - length.get());
-            other.data[slot_index*size_of::<Slot>()..(slot_index+1)*size_of::<Slot>()].copy_from_slice(Slot{ length, offset }.as_bytes());
-            data_start -= length.get();
+            let offset = U32::<NativeEndian>::from(other_data_start - length.get());
+            let new_slot_index = slot_index - split_index - 1;
+            other.data[new_slot_index*size_of::<Slot>()..(new_slot_index+1)*size_of::<Slot>()].copy_from_slice(Slot{ length, offset }.as_bytes());
+            other_data_start -= length.get();
         }
         // Update self headers
         self.header.data_start.set(new_data_start as u32);
-        self.header.free_space.set((self.data.len() - new_data_start) as u32);
-        let new_slot_count = self.header.slot_count.get() - (split_index - 1) as u16;
+        self.header.free_space.set(new_data_start as u32 - ((split_index)*8) as u32);
+        let new_slot_count = split_index as u16;
+        let old_slot_count = self.header.slot_count.get();
         self.header.slot_count.set(new_slot_count);
         // Update other headers
         other.header.data_start.set(other_data_start as u32);
-        other.header.free_space.set((other_data_end - other_data_start) as u32);
-        other.header.slot_count.set(split_index as u16);
+        let other_slot_count = old_slot_count - (split_index as u16 + 1);
+        other.header.free_space.set(other_data_end as u32 - other_data_start - other_slot_count as u32*8);
+        other.header.slot_count.set(other_slot_count);
+        other.header.first_next_pointer.set(split_key_value);
+        split_key.into_boxed_slice()
+    }
+
+    fn leaf_split_into(&mut self, other: &mut Self, other_pid_offset: u64) -> Box<[u8]> {
+        let mut split_index = 0;
+        let mut cumulative_size = 0;
+        let slots = self.get_slots();
+        // We want that both pages have at least (PAGE_SIZE - HEADER_SIZE) / 2 space after the split
+        while ((cumulative_size + slots[split_index].length.get()) as usize + 8 * (split_index + 1))  < self.data.len() / 2 {
+            let slot = &slots[split_index];
+            cumulative_size += slot.length.get();
+            split_index += 1;
+        }
+        let split_key_data = self.get_item(split_index as u16);
+        let split_key = split_key_data[..split_key_data.len() - 8].to_owned();
+        let old_data_start = self.header.data_start.get() as usize;
+        let data_end = self.data.len();
+        let new_data_start = data_end - cumulative_size as usize - split_key_data.len();
+        let new_other_size = new_data_start - old_data_start;
+        let other_data_start = other.data.len() - new_other_size;
+        let other_data_end = other.data.len();
+        let data_to_copy = &self.data[old_data_start..new_data_start];
+        other.data[other_data_start..other_data_end].copy_from_slice(data_to_copy);
+        // Update slots
+        let slots = self.get_slots_mut();
+        let mut other_data_start = other.data.len() as u32;
+        for slot_index in split_index+1..slots.len() {
+            let length = U32::<NativeEndian>::from(slots[slot_index].length.get());
+            let offset = U32::<NativeEndian>::from(other_data_start - length.get());
+            let new_slot_index = slot_index - split_index - 1;
+            other.data[new_slot_index*size_of::<Slot>()..(new_slot_index+1)*size_of::<Slot>()].copy_from_slice(Slot{ length, offset }.as_bytes());
+            other_data_start -= length.get();
+        }
+        // Update self headers
+        self.header.data_start.set(new_data_start as u32);
+        let new_slot_count = split_index as u16 + 1;
+        self.header.free_space.set(new_data_start as u32 - (new_slot_count*8) as u32);
+        let old_slot_count = self.header.slot_count.get();
+        self.header.slot_count.set(new_slot_count);
+        // Update other headers
+        other.header.data_start.set(other_data_start as u32);
+        let other_slot_count = old_slot_count - (split_index as u16 + 1);
+        other.header.free_space.set(other_data_start - (other_slot_count*8) as u32);
+        other.header.slot_count.set(other_slot_count);
+        other.header.first_next_pointer.set(self.header.first_next_pointer.get());
+        other.header.flags = self.header.flags;
+        self.header.first_next_pointer.set(other_pid_offset);
+        split_key.into_boxed_slice()
     }
 }
 
 pub struct BTreeScan<B: BufferManager> {
-    bm: B
+    segment: BTreeSegment<B>,
+    slot_id: u16,
+    page_guard: Option<BMArcReadGuard<B>>,
 }
 
 impl<B: BufferManager> Iterator for BTreeScan<B> {
-    type Item = Result<RelationTID, B::BError>;
+    type Item = Result<(Box<[Option<TupleValue>]>, RelationTID), B::BError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        todo!()
+        if let Some(page_read) = &self.page_guard {
+            let leaf = BTreePage::parse(page_read.as_ref()).unwrap();
+            let item = leaf.get_item(self.slot_id);
+            let tuple = Tuple::parse_binary_all(&self.segment.key_attributes, item[..item.len() - 8].as_ref());
+            let tid = RelationTID::from(u64::from_be_bytes(item[item.len() - 8..].try_into().unwrap()));
+            if self.slot_id + 1 < leaf.header.slot_count.get() {
+                self.slot_id += 1;
+            } else if leaf.header.first_next_pointer.get() == u64::MAX {
+                self.page_guard = None;
+            } else {
+                self.page_guard = Some(self.segment.bm.fix_page(PageId::new(self.segment.segment_id, leaf.header.first_next_pointer.get())).unwrap().read_owning());
+                self.slot_id = 0;
+            }
+            Some(Ok((tuple.values.into_boxed_slice(), tid)))
+        } else {
+            None
+        }
     }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::{seq::SliceRandom, SeedableRng};
+
+    use crate::{storage::page::PAGE_SIZE, types::{TupleValueType, TupleValue, RelationTID}};
+    use super::super::index::*;
+
+
+    #[test]
+    fn test_single_value() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(1.into())], 1.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(1.into())]).unwrap();
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(1.into())].into_boxed_slice());
+        assert_eq!(v, 1.into());
+        assert!(scan.next().is_none());
+    }
+
+    #[test]
+    fn test_two_values() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(1.into())], 11.into()).unwrap();
+        segment.insert(&[Some(2.into())], 22.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(1.into())]).unwrap();
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(1.into())].into_boxed_slice());
+        assert_eq!(v, 11.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(2.into())].into_boxed_slice());
+        assert_eq!(v, 22.into());
+        assert!(scan.next().is_none());
+    }
+
+    #[test]
+    fn test_two_values_non_ordered() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(2.into())], 22.into()).unwrap();
+        segment.insert(&[Some(1.into())], 11.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(1.into())]).unwrap();
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(1.into())].into_boxed_slice());
+        assert_eq!(v, 11.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(2.into())].into_boxed_slice());
+        assert_eq!(v, 22.into());
+        assert!(scan.next().is_none());
+    }
+
+    #[test]
+    fn test_three_values_middle() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(3.into())], 33.into()).unwrap();
+        segment.insert(&[Some(1.into())], 11.into()).unwrap();
+        segment.insert(&[Some(2.into())], 22.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(1.into())]).unwrap();
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(1.into())].into_boxed_slice());
+        assert_eq!(v, 11.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(2.into())].into_boxed_slice());
+        assert_eq!(v, 22.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(3.into())].into_boxed_slice());
+        assert_eq!(v, 33.into());
+        assert!(scan.next().is_none());
+    }
+
+    #[test]
+    fn test_three_values_lower_bound_middle() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(3.into())], 33.into()).unwrap();
+        segment.insert(&[Some(1.into())], 11.into()).unwrap();
+        segment.insert(&[Some(2.into())], 22.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(1.into())]).unwrap();
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(1.into())].into_boxed_slice());
+        assert_eq!(v, 11.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(2.into())].into_boxed_slice());
+        assert_eq!(v, 22.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(3.into())].into_boxed_slice());
+        assert_eq!(v, 33.into());
+        assert!(scan.next().is_none());
+    }
+
+
+    #[test]
+    fn test_three_values_lower_bound_end() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(3.into())], 33.into()).unwrap();
+        segment.insert(&[Some(1.into())], 11.into()).unwrap();
+        segment.insert(&[Some(2.into())], 22.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(4.into())]).unwrap();
+        assert!(scan.next().is_none());
+    }
+
+    #[test]
+    fn test_three_values_lower_bound_non_exact_match() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+        segment.insert(&[Some(4.into())], 33.into()).unwrap();
+        segment.insert(&[Some(1.into())], 11.into()).unwrap();
+        segment.insert(&[Some(3.into())], 22.into()).unwrap();
+        let mut scan = segment.lower_bound(&[Some(2.into())]).unwrap();
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(3.into())].into_boxed_slice());
+        assert_eq!(v, 22.into());
+        let (k, v) = scan.next().unwrap().unwrap();
+        assert_eq!(k, vec![Some(4.into())].into_boxed_slice());
+        assert_eq!(v, 33.into());
+        assert!(scan.next().is_none());
+    }
+
+    fn test_with_splits(mut key_values: Vec<(Option<TupleValue>, RelationTID)>) {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager.clone(), 0, vec![TupleValueType::Int]);
+        segment.init();
+
+        for (k, v) in key_values.iter() {
+            segment.insert(&[k.clone()], v.clone()).unwrap();
+        }
+        key_values.sort_by(|(k1, _), (k2, _)| k1.partial_cmp(k2).unwrap());
+        let mut scan = segment.lower_bound(&[Some(0.into())]).unwrap();
+        for (k, v) in key_values.iter() {
+            let (k2, v2) = scan.next().unwrap().unwrap();
+            assert_eq!(k, &k2[0]);
+            assert_eq!(v, &v2);
+        }
+        assert!(scan.next().is_none());
+    }
+
+    #[test]
+    fn test_with_splits_random() {
+        let num_values = PAGE_SIZE as i32;
+        let mut key_values: Vec<(Option<TupleValue>, RelationTID)> = Vec::new();
+        for i in 0i32..num_values {
+            key_values.push((Some(TupleValue::Int(i)), (i as u64).into()));
+        }
+        test_with_splits(key_values);
+    }
+
+    #[test]
+    fn test_with_splits_sequential() {
+        let num_values = PAGE_SIZE as i32;
+        let mut key_values: Vec<(Option<TupleValue>, RelationTID)> = Vec::new();
+        for i in 0i32..num_values {
+            key_values.push((Some(TupleValue::Int(i)), (i as u64).into()));
+        }
+        test_with_splits(key_values);
+    }
+
+    #[test]
+    fn test_with_splits_reverse_sequential() {
+        let num_values = PAGE_SIZE as i32;
+        let mut key_values: Vec<(Option<TupleValue>, RelationTID)> = Vec::new();
+        for i in (0i32..num_values).rev() {
+            key_values.push((Some(TupleValue::Int(i)), (i as u64).into()));
+        }
+        test_with_splits(key_values);
+    }
+
+    #[test]
+    fn test_with_splits_lower_bound() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+
+        let num_values = PAGE_SIZE as i32;
+        let mut key_values: Vec<(Option<TupleValue>, RelationTID)> = Vec::new();
+        for i in 0i32..num_values {
+            key_values.push((Some(TupleValue::Int(i)), (i as u64).into()));
+        }
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        key_values.shuffle(&mut rng);
+        for (k, v) in key_values.iter() {
+            segment.insert(&[k.clone()], v.clone()).unwrap();
+        }
+        for i in 0i32..num_values {
+            let mut scan = segment.clone().lower_bound(&[Some(i.into())]).unwrap();
+            let (k, v) = scan.next().unwrap().unwrap();
+            assert_eq!(k, vec![Some(i.into())].into_boxed_slice());
+            assert_eq!(v, (i as u64).into());
+        }
+    }
+
+    #[test]
+    fn test_with_splits_lower_bound_non_exact() {
+        let buffer_manager = crate::storage::buffer_manager::mock::MockBufferManager::new(PAGE_SIZE);
+
+        let segment = super::BTreeSegment::new(buffer_manager, 0, vec![TupleValueType::Int]);
+        segment.init();
+
+        let num_values = PAGE_SIZE as i32;
+        let mut key_values: Vec<(Option<TupleValue>, RelationTID)> = Vec::new();
+        for i in (0i32..num_values).step_by(10) {
+            key_values.push((Some(TupleValue::Int(i)), (i as u64).into()));
+        }
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        key_values.shuffle(&mut rng);
+        for (k, v) in key_values.iter() {
+            segment.insert(&[k.clone()], v.clone()).unwrap();
+        }
+        let mut scan = segment.clone().lower_bound(&[Some(5.into())]).unwrap();
+        for i in (10i32..num_values).step_by(10) {
+            let (k, v) = scan.next().unwrap().unwrap();
+            assert_eq!(k, vec![Some(i.into())].into_boxed_slice());
+            assert_eq!(v, (i as u64).into());
+        }
+        assert!(scan.next().is_none());
+    }
+
 }

--- a/src/access/btree_segment.rs
+++ b/src/access/btree_segment.rs
@@ -1,2 +1,363 @@
 
-// TODO: Implement a B+Tree using (optimistic) latch crabbing and early splitting.
+// TODO: Implement a B+Tree using (optimistic) latch crabbing
+// We will implement right-links on the leaf pages for now but not left-links bc. of deadlocks
+// Could also implement a B-Link tree using latching approach described in Lehmans & Yao paper
+
+use std::{mem::size_of, cmp::Ordering, ops::Deref};
+
+use byteorder::{BigEndian, NativeEndian};
+use zerocopy::{AsBytes, FromBytes, LayoutVerified, ByteSlice, ByteSliceMut, Unaligned, U16, U32, U64};
+
+use crate::{storage::{buffer_manager::{BufferManager, BMArcReadGuard}, page::{SegmentId, PageId, Page}}, types::{TupleValue, RelationTID, TupleValueType}};
+
+use super::{index::{OrderedIndex, Index}, tuple::{Tuple}};
+
+pub struct BTreeSegment<B: BufferManager> {
+    bm: B,
+    segment_id: SegmentId,
+    key_attributes: Vec<TupleValueType>
+}
+
+impl<B: BufferManager> BTreeSegment<B> {
+    pub fn new(bm: B, segment_id: SegmentId, key_attributes: Vec<TupleValueType>) -> Self {
+        Self {
+            bm: bm.clone(),
+            segment_id,
+            key_attributes
+        }
+    }
+
+    fn lookup_leaf_page<T: Deref<Target=Page>>(&self, key: &[Option<TupleValue>], relock_leaf: fn(BMArcReadGuard<B>) -> T)-> Result<T, B::BError> {
+        let mut parent_page = self.bm.fix_page(PageId::new(self.segment_id, 0))?.read_owning();
+        let root_page: u64 = u64::from_be_bytes(parent_page[0..8].try_into().unwrap());
+        let root_page = self.bm.fix_page(PageId::new(self.segment_id, root_page))?;
+        let mut current_page = root_page.read_owning();
+        loop {
+            if current_page[1] & 1 == 1 {
+                // Leaf page
+                return Ok(relock_leaf(current_page));
+            }
+            drop(parent_page);
+            // Still inner nodes
+            let current_bt_page = BTreeInnerPage::parse(current_page.as_ref()).unwrap();
+            let next_page_id = current_bt_page.binary_search(|val| {
+                let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                key.partial_cmp(tuple.values.as_slice()).unwrap()
+            });
+            let next_page = self.bm.fix_page(PageId::new(self.segment_id, next_page_id))?;
+            parent_page = current_page;
+            current_page = next_page.read_owning();
+        }
+    }
+}
+
+impl<B: BufferManager> Index<B> for BTreeSegment<B> {
+    fn lookup(&self, key: &[Option<TupleValue>]) -> Result<Option<RelationTID>, B::BError> {
+        let leaf_page_raw = self.lookup_leaf_page(key, |b| b)?;
+        let leaf_page = BTreeLeafPage::parse(leaf_page_raw.as_ref()).unwrap();
+        Ok(leaf_page.binary_search(|val| {
+            let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+            key.partial_cmp(tuple.values.as_slice()).unwrap()
+        }))
+    }
+
+    fn insert(&self, key: &[Option<TupleValue>], tid: RelationTID) -> Result<(), B::BError> {
+        // We first try the happy path: Taking read latches all the way down and only write locking the leaf page
+        // if we need to split the leaf page, we will retry and take a stack of write latches all the way down
+        // Since we have variable length keys (potentially, but we won't optimize the fixed-size case for now)
+        // we cannot do eager splitting and will instead have to split on demand
+        let mut page = self.lookup_leaf_page(key, |r| r.unlock().write_owning())?;
+        let mut leaf_page = BTreeLeafPage::parse(page.as_mut()).unwrap();
+        let key_binary = Tuple::new(key).get_binary();
+        if key_binary.len() + 8 + 8 <= leaf_page.header.free_space.get() as usize {
+            // don't need to split -> just insert
+            leaf_page.insert(|val| {
+                let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                key.partial_cmp(tuple.values.as_slice()).unwrap()
+            }, &key_binary, tid).unwrap();
+            Ok(())
+        } else {
+            // need to split -> retry with write latches
+            drop(leaf_page);
+            drop(page);
+            let mut latch_stack = Vec::new();
+            let mut parent_page = self.bm.fix_page(PageId::new(self.segment_id, 0))?.write_owning();
+            let root_page: u64 = u64::from_be_bytes(parent_page[0..8].try_into().unwrap());
+            let root_page = self.bm.fix_page(PageId::new(self.segment_id, root_page))?;
+            let mut current_page = root_page.write_owning();
+            loop {
+                if current_page[1] & 1 == 1 {
+                    // Leaf page
+                    let mut leaf_page = BTreeLeafPage::parse(current_page.as_mut()).unwrap();
+                    if key_binary.len() + 8 + 8 <= leaf_page.header.free_space.get() as usize {
+                        // don't need to split -> just insert
+                        leaf_page.insert(|val| {
+                            let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                            key.partial_cmp(tuple.values.as_slice()).unwrap()
+                        }, &key_binary, tid).unwrap();
+                        return Ok(());
+                    } else {
+
+                    }
+                }
+                latch_stack.push(parent_page);
+                // Still inner nodes
+                let current_bt_page = BTreeInnerPage::parse(current_page.as_ref()).unwrap();
+                let next_page_id = current_bt_page.binary_search(|val| {
+                    let tuple = Tuple::parse_binary_all(&self.key_attributes, val);
+                    key.partial_cmp(tuple.values.as_slice()).unwrap()
+                });
+                let next_page = self.bm.fix_page(PageId::new(self.segment_id, next_page_id))?;
+                parent_page = current_page;
+                current_page = next_page.write_owning();
+            }
+        }
+    }
+}
+
+impl<B: BufferManager> OrderedIndex<B> for BTreeSegment<B> {
+
+    type ScanIterator = BTreeScan<B>;
+
+    fn scan(&self, from: &[Option<TupleValue>], to: &[Option<TupleValue>]) -> Result<Self::ScanIterator, <B as BufferManager>::BError> {
+        todo!()
+    }
+}
+
+// 16 bit slot count, 16 bit first free slot, 32 bit data start, 32 bit free space
+#[repr(C)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+struct BTreePageInnerHeader {
+    flags: U16<BigEndian>,
+    slot_count: U16<NativeEndian>,
+    data_start: U32<NativeEndian>,
+    free_space: U32<NativeEndian>,
+    last_pointer: U64<NativeEndian>
+}
+
+/*
+    The inner page contains the header after which the slots follow. 
+    The values contain a variable sized tuple (the key) followed by a 64 bit page id.
+ */
+
+#[repr(C)]
+#[derive(FromBytes)]
+struct BTreeInnerPage<B: ByteSlice> {
+    header: LayoutVerified<B, BTreePageInnerHeader>,
+    data: B
+}
+
+#[repr(C)]
+#[derive(FromBytes, Unaligned, AsBytes)]
+struct Slot {
+    offset: U32<NativeEndian>,
+    length: U32<NativeEndian>
+}
+
+impl<B: ByteSlice> BTreeInnerPage<B> {
+    fn parse(bytes: B) -> Option<BTreeInnerPage<B>> {
+        let (header, data) = LayoutVerified::new_unaligned_from_prefix(bytes)?;
+        Some(BTreeInnerPage { header, data })
+    }
+
+    fn get_slots(&self) -> &[Slot] {
+        let slot_count = self.header.slot_count.get() as usize;
+        let slot_size = size_of::<Slot>();
+        let slots = &self.data.as_ref()[0..slot_count * slot_size];
+        let layout: LayoutVerified<&[u8], [Slot]> = LayoutVerified::new_slice(slots).unwrap();
+        layout.into_slice()
+    }
+
+    fn binary_search<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> u64 {
+        let slots = self.get_slots();
+        let mut left = 0;
+        let mut right = slots.len();
+        while left < right {
+            let mid = (left + right) / 2;
+            let slot = &slots[mid];
+            let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
+            match comp(&data[..data.len() - 8]) {
+                Ordering::Less => {
+                    right = mid;
+                },
+                Ordering::Equal => {
+                    return u64::from_be_bytes(data[data.len() - 8..].try_into().unwrap());
+                },
+                Ordering::Greater => {
+                    left = mid + 1;
+                }
+            }
+        }
+        if right == slots.len() {
+            self.header.last_pointer.get()
+        } else {
+            let slot = &slots[right];
+            let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
+            u64::from_be_bytes(data[data.len() - 8..].try_into().unwrap())
+        }
+    }
+    
+}
+
+impl<B: ByteSliceMut> BTreeInnerPage<B> {
+    
+}
+
+// 16 bit slot count, 16 bit first free slot, 32 bit data start, 32 bit free space
+#[repr(C)]
+#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+struct BTreePageLeafHeader {
+    flags: U16<BigEndian>,
+    slot_count: U16<NativeEndian>,
+    data_start: U32<NativeEndian>, // Not really necessary. It's just the offset of the first slot
+    free_space: U32<NativeEndian>, // Not really necessary. It's just the data length minus data_start
+}
+
+#[repr(C)]
+#[derive(FromBytes)]
+struct BTreeLeafPage<B: ByteSlice> {
+    header: LayoutVerified<B, BTreePageLeafHeader>,
+    data: B
+}
+
+impl<B: ByteSlice> BTreeLeafPage<B> {
+    pub fn parse(bytes: B) -> Option<BTreeLeafPage<B>> {
+        let (header, data) = LayoutVerified::new_unaligned_from_prefix(bytes)?;
+        Some(BTreeLeafPage { header, data })
+    }
+
+    fn get_slots(&self) -> &[Slot] {
+        let slot_count = self.header.slot_count.get() as usize;
+        let slot_size = size_of::<Slot>();
+        let slots = &self.data.as_ref()[0..slot_count * slot_size];
+        let layout: LayoutVerified<&[u8], [Slot]> = LayoutVerified::new_slice(slots).unwrap();
+        layout.into_slice()
+    }
+
+    fn binary_search_slot<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> Option<(usize, bool)> {
+        let slots = self.get_slots();
+        let mut left = 0;
+        let mut right = slots.len();
+        while left < right {
+            let mid = (left + right) / 2;
+            let slot = &slots[mid];
+            let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
+            match comp(&data[..data.len() - 8]) {
+                Ordering::Less => {
+                    right = mid;
+                },
+                Ordering::Equal => {
+                    return Some((mid, true));
+                },
+                Ordering::Greater => {
+                    left = mid + 1;
+                }
+            }
+        }
+        if right < slots.len() {
+            let slot = &slots[right];
+            let data = &self.data.as_ref()[slot.offset.get() as usize..(slot.offset.get() + slot.length.get()) as usize];
+            if comp(&data[..data.len() - 8]) == Ordering::Equal {
+                return Some((right, true));
+            }
+        }
+        None
+    }
+
+    fn binary_search<C: Fn(&[u8]) -> Ordering>(&self, comp: C) -> Option<RelationTID> {
+        self.binary_search_slot(comp).map(|(s, exact_match)| {
+            let slot = &self.get_slots()[s];
+            let value_end = (slot.offset.get() + slot.length.get()) as usize;
+            let value_start = value_end - 8;
+            // Check whether the key actually matches
+            if !exact_match {
+                return None;
+            }
+            Some(RelationTID::from(u64::from_be_bytes(self.data[value_start..value_end].try_into().unwrap())))
+        }
+        ).flatten()
+    }
+}
+
+impl<B: ByteSliceMut> BTreeLeafPage<B> {
+
+    fn insert<C: Fn(&[u8]) -> Ordering>(&mut self, comp: C, key: &[u8], value: RelationTID) -> Result<(), ()> {
+        let slot = self.binary_search_slot(comp).to_owned();
+        let (slot_index, move_end) = if let Some((slot_index, exact_match)) = slot {
+            if exact_match {
+                return Err(());
+            }
+            let slot: &Slot = &self.get_slots()[slot_index];
+            (slot_index, (slot.offset.get() + slot.length.get()) as usize)
+        } else {
+            // Insert at the end
+            (self.header.slot_count.get() as usize, self.data.len())
+        };
+        // Move greaters slots and insert
+        self.data.copy_within(self.header.slot_count.get() as usize * size_of::<Slot>()..move_end, self.header.slot_count.get() as usize * size_of::<Slot>() - size_of::<Slot>());
+        // Move smaller elements and insert
+        let insert_len = key.len() + 8;
+        self.data.copy_within(self.header.data_start.get() as usize..move_end, self.header.data_start.get() as usize - insert_len);
+        self.data[move_end-insert_len..move_end-8].copy_from_slice(key);
+        self.data[move_end-8..move_end].copy_from_slice(&u64::from(&value).to_be_bytes());
+        // Update header
+        let slots = self.header.slot_count.get();
+        self.header.slot_count.set(slots + 1);
+        let data_start = self.header.data_start.get();
+        self.header.data_start.set(data_start - insert_len as u32);
+        let free_space = self.header.free_space.get();
+        self.header.free_space.set(free_space - insert_len as u32);
+        Ok(())
+    }
+
+    fn split_into(&mut self, other: &mut Self) {
+        let mut split_index = 0;
+        let mut cumulative_size = 0;
+        let slots = self.get_slots();
+        // We want that both pages have at least (PAGE_SIZE - HEADER_SIZE) / 2 space after the split
+        while ((cumulative_size + slots[split_index].length.get()) as usize)  < self.data.len() / 2 {
+            let slot = &slots[split_index];
+            cumulative_size += slot.length.get();
+            split_index += 1;
+        }
+        let split_key = self.data.as_ref()[slots[split_index].offset.get() as usize..(slots[split_index].offset.get() + slots[split_index].length.get() - 8) as usize].to_owned();
+        let old_data_start = self.header.data_start.get() as usize;
+        let new_other_size = self.data.len() - old_data_start - cumulative_size as usize - split_key.len();
+        let other_data_start = other.data.len() - new_other_size;
+        let other_data_end = other.data.len();
+        let data_to_copy = &self.data[self.data.len() - new_other_size..self.data.len()];
+        other.data[other_data_start..other_data_end].copy_from_slice(data_to_copy);
+        let data_end = self.data.len();
+        let new_data_start = data_end - cumulative_size as usize;
+        self.data.copy_within(old_data_start..data_end, new_data_start);
+        // Update slotsenumerate
+        let mut data_start = other.data.len() as u32;
+        let slots = self.get_slots();
+        for slot_index in (0..split_index).rev() {
+            let length = U32::<NativeEndian>::from(slots[slot_index].length.get());
+            let offset = U32::<NativeEndian>::from(data_start - length.get());
+            other.data[slot_index*size_of::<Slot>()..(slot_index+1)*size_of::<Slot>()].copy_from_slice(Slot{ length, offset }.as_bytes());
+            data_start -= length.get();
+        }
+        // Update self headers
+        self.header.data_start.set(new_data_start as u32);
+        self.header.free_space.set((self.data.len() - new_data_start) as u32);
+        self.header.slot_count.set(self.header.slot_count.get() - split_index - 1 as u16);
+        // Update other headers
+        other.header.data_start.set(other_data_start as u32);
+        other.header.free_space.set((other_data_end - other_data_start) as u32);
+        other.header.slot_count.set(split_index as u16);
+    }
+}
+
+pub struct BTreeScan<B: BufferManager> {
+    bm: B
+}
+
+impl<B: BufferManager> Iterator for BTreeScan<B> {
+    type Item = Result<RelationTID, B::BError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}

--- a/src/access/index.rs
+++ b/src/access/index.rs
@@ -1,0 +1,19 @@
+use crate::{storage::buffer_manager::BufferManager, types::{RelationTID, TupleValue}};
+
+
+
+// A basic index doesn't need to support range scans (hash tables for example don't)
+pub trait Index<B: BufferManager> {
+    fn lookup(&self, key: &[Option<TupleValue>]) -> Result<Option<RelationTID>, B::BError>;
+    fn insert(&self, key: &[Option<TupleValue>], tid: RelationTID) -> Result<(), B::BError>;
+    // fn update(&self, tid: RelationTID, tuple: Tuple) -> Result<(), B::BError>; Update doesn't really make sense in a transactional context, you'll possibly want to access old and new values at the same time
+    // fn delete(&self, tid: RelationTID) -> Result<(), B::BError>; No deletes for now. Deletes must be handled differently later with transactions anyway (GC)
+}
+
+pub trait OrderedIndex<B: BufferManager>: Index<B> {
+    // Probably doesn't really make much sense to have a predicate here since we have
+    // an Index
+    type ScanIterator: Iterator<Item = Result<RelationTID, B::BError>>;
+
+    fn scan(&self, from: &[Option<TupleValue>], to: &[Option<TupleValue>]) -> Result<Self::ScanIterator, B::BError>;
+}

--- a/src/access/index.rs
+++ b/src/access/index.rs
@@ -3,9 +3,11 @@ use crate::{storage::buffer_manager::BufferManager, types::{RelationTID, TupleVa
 
 
 // A basic index doesn't need to support range scans (hash tables for example don't)
+// It will always be a unique index
 pub trait Index<B: BufferManager> {
     fn lookup(&self, key: &[Option<TupleValue>]) -> Result<Option<RelationTID>, B::BError>;
-    fn insert(&self, key: &[Option<TupleValue>], tid: RelationTID) -> Result<(), B::BError>;
+    // The result is a bool indicating whether uniqueness was violated
+    fn insert(&self, key: &[Option<TupleValue>], tid: RelationTID) -> Result<bool, B::BError>;
     // fn update(&self, tid: RelationTID, tuple: Tuple) -> Result<(), B::BError>; Update doesn't really make sense in a transactional context, you'll possibly want to access old and new values at the same time
     // fn delete(&self, tid: RelationTID) -> Result<(), B::BError>; No deletes for now. Deletes must be handled differently later with transactions anyway (GC)
 }
@@ -13,7 +15,8 @@ pub trait Index<B: BufferManager> {
 pub trait OrderedIndex<B: BufferManager>: Index<B> {
     // Probably doesn't really make much sense to have a predicate here since we have
     // an Index
-    type ScanIterator: Iterator<Item = Result<RelationTID, B::BError>>;
+    type ScanIterator: Iterator<Item = Result<(Box<[Option<TupleValue>]>, RelationTID), B::BError>>;
 
-    fn scan(&self, from: &[Option<TupleValue>], to: &[Option<TupleValue>]) -> Result<Self::ScanIterator, B::BError>;
+    // Will scan from the specified to the specified value, both ends beeing inclusive
+    fn scan(&self, from: Option<&[Option<TupleValue>]>, to: Option<&[Option<TupleValue>]>) -> Result<Self::ScanIterator, B::BError>;
 }

--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -2,6 +2,7 @@ mod free_space_inventory;
 mod btree_segment;
 mod slotted_page_segment;
 mod heap;
+mod index;
 pub mod tuple;
 
 pub use self::btree_segment::*;

--- a/src/access/slotted_page_segment.rs
+++ b/src/access/slotted_page_segment.rs
@@ -5,7 +5,7 @@ use crate::{storage::{buffer_manager::{BufferManager, BMArc}, page::{Page, PAGE_
 use super::{free_space_inventory::FreeSpaceSegment, tuple::{Tuple, TupleParser, MutatingTupleParser}};
 
 // We implement a safe variant for now. Transmuting stuff like the header will likely lead to more
-// readable code but would need unsafe
+// readable code but would need unsafe (maybe possible with zerocopy)
 
 // 16 bit slot count, 16 bit first free slot, 32 bit data start, 32 bit free space
 const HEADER_SIZE: usize = 2 * 4 + 2 * 2; 
@@ -414,6 +414,7 @@ impl<'a, V: BorrowMut<Option<TupleValue>> + 'a> ScanFunction<()> for MutatingTup
     }
 }
 
+// Probably just cache all the tuples from a single page instead of constantly locking and unlocking the page
 pub struct SlottedPageScan<B: BufferManager, T, F: ScanFunction<T>> {
     segment: SlottedPageSegment<B>,
     page: Option<BMArc<B>>,

--- a/src/access/slotted_page_segment.rs
+++ b/src/access/slotted_page_segment.rs
@@ -242,7 +242,6 @@ impl<B: BufferManager> SlottedPageSegment<B> {
                 if let Slot::Slot { offset, length } = slotted_root_page.get_slot(tid.slot_id) {
                     operation(slotted_root_page.get_record_mut(offset, length));
                     self.free_space_segment.update_page_size(tid.page_id, slotted_root_page.get_free_space())?;
-                    drop(slotted_root_page);
                     slotted_redirect_target_page.erase(redirect_tid.slot_id);
                     self.free_space_segment.update_page_size(redirect_tid.page_id, slotted_redirect_target_page.get_free_space())?;
                     return Ok(true);
@@ -253,7 +252,6 @@ impl<B: BufferManager> SlottedPageSegment<B> {
             let orig_relocate_result = slotted_redirect_target_page.relocate(redirect_tid.slot_id, size + 8);
             if orig_relocate_result {
                 if let Slot::RedirectTarget { offset, length } = slotted_redirect_target_page.get_slot(redirect_tid.slot_id) {
-                    drop(slotted_root_page);
                     operation(slotted_redirect_target_page.get_record_mut(offset + 8, length - 8));
                     self.free_space_segment.update_page_size(redirect_tid.page_id, slotted_redirect_target_page.get_free_space())?;
                     return Ok(true);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,6 @@
+// First gen parser for OxidSQL. I will probably integrate the sqlparser crate instead. 
+// There's not really much to gain from writing a parser from scratch, and it's a lot of work.
+
 /*
     TODO: Implement a parser for the SQL dialect supported by the database (likely using the nom
           parser combinator library). The parser should produce an abstract syntax tree (AST) that 
@@ -18,7 +21,7 @@ use nom::character::complete::{multispace0, multispace1, char, digit1};
 use nom::combinator::{opt, map_res, map};
 use nom::sequence::{delimited, tuple, preceded};
 use nom::branch::alt;
-use nom::character::{is_alphanumeric};
+use nom::character::is_alphanumeric;
 use nom::multi::separated_list1;
 use nom::error::ParseError;
 

--- a/src/statistics/counting_hyperloglog.rs
+++ b/src/statistics/counting_hyperloglog.rs
@@ -16,8 +16,7 @@
 
  */
 
-use std::sync::atomic::{AtomicU8};
-use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::{Ordering::Relaxed, AtomicU8};
 
 use itertools::Itertools;
 
@@ -164,6 +163,11 @@ impl<R: Fn(f64) -> bool> CountingHyperLogLog<R> {
     pub fn to_bytes(&self) -> [u8; 59 * 64] {
         self.into()
     }
+    
+    // TODO: Implement merge/union and intersection 
+    //      (Not as trivial as for non-counting HLLs because we 
+    //       have to deal with probabilistic counters)
+
 }
 
 /// Make sure you only call this when you're sure that the CountingHyperLogLog is not being updated

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -61,4 +61,11 @@ pub mod sampling;
 
     Generally the findings of this paper should be followed: https://www.vldb.org/pvldb/vol9/p204-leis.pdf
 
+    Since the data structures maintained for the statistics are in-memory and will
+    only be written to disk for checkpoints or on (regular) shutdown we will have to
+    take some kind of exclusive lock on all modifications to stop all modifications to the database
+    for a very short amount of time while we take a consistent snapshot of our statistics data-structures
+    that we then write to disk. This should be fine since this will only happen every few minutes and will
+    only take a few microseconds to milliseconds. Another possibility would be just writing it on orderly
+    shutdown and rebuilding on recovery.
  */

--- a/src/statistics/sampling.rs
+++ b/src/statistics/sampling.rs
@@ -134,10 +134,6 @@ pub struct SkipGuard<'a, R: Fn() -> f32 + Clone> {
     list_index: u32,
     skip: &'a Skip,
     sampler: &'a ReservoirSampler<R>,
-    // The snapshot latch is there to enable atomic snapshots of the list of skips
-    // Every SkipGuard gets a RwReadGuard so that we can make sure to only take
-    // a snapshot when no other thread is currently owning any SkipGuard
-    _snapshot_latch_guard: RwLockReadGuard<'a, ()>,
 }
 
 impl<'a, R: Fn() -> f32 + Clone> SkipGuard<'a, R> {
@@ -470,10 +466,6 @@ impl<'a, R: Fn() -> f32 + Clone> ListOfSkips<R> {
 pub struct ReservoirSampler<R: Fn() -> f32 + Clone = fn() -> f32> {
     list_of_skips: ListOfSkips<R>,
     sample_size: u32,
-    // We will probably have to increment a version counter on every modification. I think this is probably neccesary
-    // for recovery once it is implemented to be able to see what has to be undone/redone.
-    // We will then just log the version with any modification to the LoS to the WAL
-    snapshot_latch: RwLock<()>,
 }
 
 impl ReservoirSampler<fn() -> f32> {
@@ -492,7 +484,6 @@ impl<'a, R: Fn() -> f32 + Clone> ReservoirSampler<R> {
         ReservoirSampler {
             list_of_skips: ListOfSkips::new(n_threads, sample_size, random),
             sample_size,
-            snapshot_latch: RwLock::new(()),
         }
     }
 
@@ -503,12 +494,10 @@ impl<'a, R: Fn() -> f32 + Clone> ReservoirSampler<R> {
         return ReservoirSampler {
             list_of_skips: los,
             sample_size,
-            snapshot_latch: RwLock::new(()),
         }      
     }
 
     pub fn get_skip(&'a self) -> SkipGuard<'a, R> {
-        let _snapshot_latch_guard = self.snapshot_latch.read();
         let (list_index, skip) = self.list_of_skips.get_skip();
         return SkipGuard {
             list_index,
@@ -517,17 +506,14 @@ impl<'a, R: Fn() -> f32 + Clone> ReservoirSampler<R> {
             skip_count: skip.length.load(Relaxed),
             skip_index: skip.index.load(Relaxed),
             proccessed: 0,
-            _snapshot_latch_guard
         }
     }
 
     pub fn delete_sample(&self, index: u32) {
-        let _snapshot_latch_guard = self.snapshot_latch.read();
         self.list_of_skips.delete_sample(index);
     } 
 
     pub fn delete_skipped(&self, n: usize) {
-        let _snapshot_latch_guard = self.snapshot_latch.read();
         // We successfully increased the number of skips
         // We can now delete the skipped tuple
         let mut skip = self.get_skip();
@@ -535,7 +521,6 @@ impl<'a, R: Fn() -> f32 + Clone> ReservoirSampler<R> {
     }
 
     pub fn snapshot(&self) -> Vec<u8> {
-        let _snapshot_latch = self.snapshot_latch.write();
         let mut bytes = Vec::new();
         let mut cursor = Cursor::new(&mut bytes);
         cursor.write_u32::<BigEndian>(self.sample_size).unwrap();

--- a/src/statistics/sampling.rs
+++ b/src/statistics/sampling.rs
@@ -41,7 +41,7 @@ use std::sync::atomic::Ordering::Relaxed;
 
 use atomic::Ordering;
 use byteorder::{ReadBytesExt, BigEndian, WriteBytesExt};
-use parking_lot::{RwLock, RwLockReadGuard, Mutex};
+use parking_lot::Mutex;
 
 // Quick and Hacky Atomic f32, u32 tuple
 pub struct AtomicU32F32Tup {
@@ -386,7 +386,11 @@ impl<'a, R: Fn() -> f32 + Clone> ListOfSkips<R> {
     /// Only call when there's no other thread accessing the list
     /// Otherwise we cannot possibly serialize the entire list since it might change
     /// while we're serializing it
-    /// We'll probably achieve this by using a RwLock over the entire 
+    /// This should probably only be called on orderly shutdown. For everything else we will just 
+    /// write the skip number that inserted a tuple to each tuple in the sample.
+    /// It should however be possible to reconstruct a pretty much equivalent skip list
+    /// by just initializing the sampler in a way that takes into account the total number of
+    /// tuples in the table.
     fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         let mut cursor = Cursor::new(&mut bytes);

--- a/src/storage/buffer_manager.rs
+++ b/src/storage/buffer_manager.rs
@@ -74,6 +74,14 @@ impl<B: BufferManager> BMArcUpgradeableReadGuard<B> {
     }
 }
 
+impl<B: BufferManager> Deref for BMArcUpgradeableReadGuard<B> {
+    type Target = Page;
+
+    fn deref(&self) -> &Self::Target {
+        &self.page
+    }
+}
+
 impl<B: BufferManager> Deref for BMArcReadGuard<B> {
     type Target = Page;
 
@@ -128,6 +136,10 @@ impl<'a, B: BufferManager> BMArc<B> {
 
     pub fn write_owning(self) -> BMArcWriteGuard<B> {
         BMArcWriteGuard::new(self)
+    }
+
+    pub fn upgradeable_read_owning(self) -> BMArcUpgradeableReadGuard<B> {
+        BMArcUpgradeableReadGuard::new(self)
     }
 
     pub fn read_owning(self) -> BMArcReadGuard<B> {

--- a/src/storage/buffer_manager.rs
+++ b/src/storage/buffer_manager.rs
@@ -70,6 +70,7 @@ impl<B: BufferManager> BMArcUpgradeableReadGuard<B> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn unlock(self) -> BMArc<B> {
         self.bmarc
     }
@@ -107,6 +108,7 @@ impl<B: BufferManager> BMArcWriteGuard<B> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn unlock(self) -> BMArc<B> {
         self.bmarc
     }

--- a/src/storage/clock_replacer.rs
+++ b/src/storage/clock_replacer.rs
@@ -40,7 +40,7 @@ impl Replacer for ClockReplacer {
     // We do at best two sweeps. First sweep takes into account clock status
     // Second basically just automatically takes the first that isn't currently referenced
     while n_iterated < self.clock.len() * 2 && victim.is_none() {
-      let mut element = &mut self.clock[self.clock_position];
+      let element = &mut self.clock[self.clock_position];
       if !element.clock_used && can_page_be_replaced(&element.page) {
         victim = Option::Some(element.page_id);
       }

--- a/src/storage/page.rs
+++ b/src/storage/page.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor};
+use std::io::Cursor;
 use std::convert::TryInto;
 use std::ops::{Deref, DerefMut};
 use byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -7,7 +7,7 @@
     paper "Memory-Optimized Multi-Version Concurrency Control for Disk-Based Database Systems" 
     (https://db.in.tum.de/~freitag/papers/p2797-freitag.pdf?lang=en). This should be rather fast
     and allows me to avoid having to write a lock manager (which would be something between a PITA 
-    and impossible in safe Rust). 
+    and impossible to implement in a performant way in safe Rust). 
 
     One mistake that Postgres made that i will definitely not make is using 4-byte transaction ids.
  */

--- a/src/types.rs
+++ b/src/types.rs
@@ -257,6 +257,42 @@ impl Display for TupleValue {
     }
 }
 
+impl From::<i64> for TupleValue {
+    fn from(input: i64) -> Self {
+        TupleValue::BigInt(input)
+    }
+}
+
+impl From::<i32> for TupleValue {
+    fn from(input: i32) -> Self {
+        TupleValue::Int(input)
+    }
+}
+
+impl From::<i16> for TupleValue {
+    fn from(input: i16) -> Self {
+        TupleValue::SmallInt(input)
+    }
+}
+
+impl From::<String> for TupleValue {
+    fn from(input: String) -> Self {
+        TupleValue::String(input)
+    }
+}
+
+impl From::<&str> for TupleValue {
+    fn from(input: &str) -> Self {
+        TupleValue::String(input.to_string())
+    }
+}
+
+impl From::<Box<[u8]>> for TupleValue {
+    fn from(input: Box<[u8]>) -> Self {
+        TupleValue::ByteArray(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
As a prerequisite for indexes i implemented a basic B+Tree with Latch-crabbing. This was quite tricky to get right in safe Rust and i don't think it is possible using the normal Lock guards of the std or parking_lot Mutex/RWLocks which borrow from the locks themselves but luckily parking_lot has an optional feature called arc_lock which allows you to own your lock guards if the locks are wrapped inside an Arc (which my Pages are). I also implemented a basic iterator over the tree which will then be wrapped inside one that will then actually iterate over TIDs with an upper and lower bound which will then be used for Index Scans during query processing.